### PR TITLE
Enable renovate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,11 +14,11 @@ jobs:
         with:
           fetch-depth: 2
 
-      # - name: Login to DockerHub
-      #   uses: docker/login-action@v1
-      #   with:
-      #     username: ${{ secrets.DOCKER_HUB_USER }}
-      #     password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Build and push
         run: make all

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
 
       # - name: Login to DockerHub
       #   uses: docker/login-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   build:
@@ -9,11 +12,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      # - name: Login to DockerHub
+      #   uses: docker/login-action@v1
+      #   with:
+      #     username: ${{ secrets.DOCKER_HUB_USER }}
+      #     password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Build and push
         run: make all

--- a/build.sh
+++ b/build.sh
@@ -39,11 +39,11 @@ tag_and_push() {
   if [[ "${target}" != *":"* ]]; then
     target="${target}:$(cut -d: -f2 <<< "$source" | cut -d@ -f1)"
   fi
-  # docker pull "${source}"
+  docker pull "${source}"
   echo "tagging ${source} as ${target}"
-  # docker tag "${source}" "${target}"
+  docker tag "${source}" "${target}"
   echo "pushing ${target}"
-  # docker push "${target}"
+  docker push "${target}"
 }
 
 get_tag

--- a/build.sh
+++ b/build.sh
@@ -37,7 +37,7 @@ tag_and_push() {
 
   read -r source target <<< "$(echo "$image_line"|cut -d, -s -f1,2 --output-delimiter=' ')"
   if [[ "${target}" != *":"* ]]; then
-    target="${target}:$(cut -d: -f2 <<< "$source")"
+    target="${target}:$(cut -d: -f2 <<< "$source" | cut -d@ -f1)"
   fi
   # docker pull "${source}"
   echo "tagging ${source} as ${target}"

--- a/build.sh
+++ b/build.sh
@@ -2,14 +2,70 @@
 
 set -eo pipefail
 
-for item in $(cat workload.txt|grep ready|grep -v "^#");
-do
-  read source target <<< $(echo $item|awk -F"," '{print $1" "$2}')
-  docker pull ${source}
+current_hash=$(git log --pretty=format:'%h' --max-count=1)
+current_branch=$(git branch --show-current|sed 's#/#_#')
+
+version=""
+compare_to="HEAD~1"
+
+get_tag() {
+  if [[ ${current_branch} == "main" ]]; then
+    git fetch --tags --force
+    current_version_at_head=$(git tag --points-at HEAD)
+    if [[ -z ${current_version_at_head} ]] || [[ ! "${current_version_at_head}" =~ ^v+ ]]; then 
+      commit_hash=$(git rev-list --tags --topo-order --max-count=1)
+      latest_version=""
+      if [[ "${commit_hash}" != "" ]]; then
+        latest_version=$(git describe --tags "${commit_hash}" 2>/dev/null)
+      fi
+      if [[ ${latest_version} =~ ^v+ ]]; then 
+        compare_to=${latest_version}
+        read -r a b c <<< "${version//./ }"
+        version="$a.$b.$((c+1))"
+      else
+        version="v1.0.0"
+      fi
+      echo "version: ${version}"
+    else
+      echo nothing to build
+    fi
+  fi
+}
+
+tag_and_push() {
+  local image_line=$1
+
+  read -r source target <<< "$(echo "$image_line"|cut -d, -s -f1,2 --output-delimiter=' ')"
+  # docker pull "${source}"
   echo "tagging ${source} as ${target}"
-  docker tag ${source} ${target}
+  # docker tag "${source}" "${target}"
   echo "pushing ${target}"
-  docker push ${target}
-done;
+  # docker push "${target}"
+}
 
+get_tag
 
+changed_files=$(git diff --name-only HEAD "${compare_to}")
+echo "Files changed from HEAD to ${compare_to}:"
+echo "${changed_files}"
+
+# Renovated images changed - build changed ones
+if grep -q "^renovated_images.txt$" <<< "$changed_files"; then
+  git diff -w HEAD "${compare_to}" renovated_images.txt | grep "^+[^+]" | cut -c2- | while IFS= read -r item; do
+    tag_and_push "$item"
+  done
+fi
+
+# workload.txt (manually maintained) changed or some other change (e.g. empty commit) - build ready images from workload.txt
+if grep -q "^workload.txt$" <<< "$changed_files" || ! grep -q "^renovated_images.txt$" <<< "$changed_files"; then
+  grep "ready" workload.txt | grep -v "^#" | while IFS= read -r item; do
+    tag_and_push "$item"
+  done
+fi
+
+# Tag with the new version
+if [[ -n ${version} ]]; then
+  now=$(date '+%Y-%m-%dT%H:%M:%S%z')
+  git tag -m "{\"author\":\"ci\", \"branch\":\"$current_branch\", \"hash\": \"${current_hash}\", \"version\":\"${version}\",  \"build_date\":\"${now}\"}"  ${version}
+  git push --tags
+fi

--- a/build.sh
+++ b/build.sh
@@ -51,7 +51,7 @@ echo "${changed_files}"
 
 # Renovated images changed - build changed ones
 if grep -q "^renovated_images.txt$" <<< "$changed_files"; then
-  git diff -w HEAD "${compare_to}" renovated_images.txt | grep "^+[^+]" | cut -c2- | while IFS= read -r item; do
+  git diff -w HEAD "${compare_to}" renovated_images.txt | grep "^+[^+]" | cut -c2- | grep -v "^#" | while IFS= read -r item; do
     tag_and_push "$item"
   done
 fi

--- a/build.sh
+++ b/build.sh
@@ -36,6 +36,9 @@ tag_and_push() {
   local image_line=$1
 
   read -r source target <<< "$(echo "$image_line"|cut -d, -s -f1,2 --output-delimiter=' ')"
+  if [[ "${target}" != *":"* ]]; then
+    target="${target}:$(cut -d: -f2 <<< "$source")"
+  fi
   # docker pull "${source}"
   echo "tagging ${source} as ${target}"
   # docker tag "${source}" "${target}"

--- a/build.sh
+++ b/build.sh
@@ -54,7 +54,7 @@ echo "${changed_files}"
 
 # Renovated images changed - build changed ones
 if grep -q "^renovated_images.txt$" <<< "$changed_files"; then
-  git diff -w "${compare_from}" HEAD renovated_images.txt | grep "^+[^+]" | cut -c2- | grep -v "^#" | while IFS= read -r item; do
+  git diff -w "${compare_from}" HEAD renovated_images.txt | { grep "^+[^+]" || true; } | cut -c2- | { grep -v "^#" || true; } | while IFS= read -r item; do
     tag_and_push "$item"
   done
 fi

--- a/build.sh
+++ b/build.sh
@@ -66,6 +66,12 @@ fi
 # Tag with the new version
 if [[ -n ${version} ]]; then
   now=$(date '+%Y-%m-%dT%H:%M:%S%z')
+
+  # shellcheck source=/dev/null
+  source project.properties
+  git config --global user.email "${email:?}"
+  git config --global user.name "${name:?}"
+
   git tag -m "{\"author\":\"ci\", \"branch\":\"$current_branch\", \"hash\": \"${current_hash}\", \"version\":\"${version}\",  \"build_date\":\"${now}\"}"  ${version}
   git push --tags
 fi

--- a/build.sh
+++ b/build.sh
@@ -20,7 +20,7 @@ get_tag() {
       fi
       if [[ ${latest_version} =~ ^v+ ]]; then 
         compare_to=${latest_version}
-        read -r a b c <<< "${version//./ }"
+        read -r a b c <<< "${latest_version//./ }"
         version="$a.$b.$((c+1))"
       else
         version="v1.0.0"

--- a/project.properties
+++ b/project.properties
@@ -1,0 +1,2 @@
+name="Image Miner"
+email=imagemine2021@gmail.com

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,9 @@
   "extends": [
     "config:base"
   ],
+  "ignorePresets": [
+    ":prHourlyLimit2"
+  ],
   "docker": {
     "pinDigests": true
   },

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base"
+  ],
+  "docker": {
+    "pinDigests": true
+  },
+  "regexManagers": [
+    {
+      "fileMatch": [
+        "^renovated_images.txt$"
+      ],
+      "matchStrings": [
+        "(?<depName>.*?):(?<currentValue>.*?)@?(?<currentDigest>sha256:[a-f0-9]+)?,.*"
+      ],
+      "datasourceTemplate": "docker"
+    }
+  ]
+}

--- a/renovated_images.txt
+++ b/renovated_images.txt
@@ -2,4 +2,7 @@
 # Format: {source_image}:{tag}[@{optional_sha256_digest}],{target_image_without_tag}
 # Target image tag will be the same as source image tag
 
-
+node:16.15.0-alpine,cloudnativek8s/node
+nginx:1.22.0-alpine,cloudnativek8s/nginx
+openpolicyagent/opa:0.41.0,cloudnativek8s/opa
+openpolicyagent/opa:0.41.0-debug,cloudnativek8s/opa

--- a/renovated_images.txt
+++ b/renovated_images.txt
@@ -1,2 +1,2 @@
 # The versions in this file are maintained by renovate bot
-postgres,cloudnativek8s/postgres:12.1
+postgres,cloudnativek8s/postgres:12.2

--- a/renovated_images.txt
+++ b/renovated_images.txt
@@ -1,5 +1,5 @@
 # The versions in this file are maintained by renovate bot
-# Format: {source_image}:{tag}@{sha256_digest}],{target_image_without_tag}
+# Format: {source_image}:{tag}@{sha256_digest},{target_image_without_tag}
 # Target image tag will be the same as source image tag
 
 node:16.15.0-alpine@sha256:bb776153f81d6e931211e3cadd7eef92c811e7086993b685d1f40242d486b9bb,cloudnativek8s/node

--- a/renovated_images.txt
+++ b/renovated_images.txt
@@ -1,0 +1,2 @@
+# The versions in this file are maintained by renovate bot
+postgres,cloudnativek8s/postgres:12.1,done

--- a/renovated_images.txt
+++ b/renovated_images.txt
@@ -2,7 +2,4 @@
 # Format: {source_image}:{tag}[@{optional_sha256_digest}],{target_image_without_tag}
 # Target image tag will be the same as source image tag
 
-node:16.15.0-alpine,cloudnativek8s/node
-nginx:1.22.0-alpine,cloudnativek8s/nginx
-openpolicyagent/opa:0.41.0,cloudnativek8s/opa
-openpolicyagent/opa:0.41.0-debug,cloudnativek8s/opa
+

--- a/renovated_images.txt
+++ b/renovated_images.txt
@@ -1,2 +1,2 @@
 # The versions in this file are maintained by renovate bot
-postgres,cloudnativek8s/postgres:12.2
+postgres,cloudnativek8s/postgres:12.3

--- a/renovated_images.txt
+++ b/renovated_images.txt
@@ -1,2 +1,8 @@
 # The versions in this file are maintained by renovate bot
-postgres,cloudnativek8s/postgres:12.3
+# Format: {source_image}:{tag}[@{optional_sha256_digest}],{target_image_without_tag}
+# Target image tag will be the same as source image tag
+
+node:16.15.0-alpine,cloudnativek8s/node
+nginx:1.22.0-alpine,cloudnativek8s/nginx
+openpolicyagent/opa:0.41.0,cloudnativek8s/opa
+openpolicyagent/opa:0.41.0-debug,cloudnativek8s/opa

--- a/renovated_images.txt
+++ b/renovated_images.txt
@@ -1,2 +1,2 @@
 # The versions in this file are maintained by renovate bot
-postgres,cloudnativek8s/postgres:12.1,done
+postgres,cloudnativek8s/postgres:12.1

--- a/renovated_images.txt
+++ b/renovated_images.txt
@@ -1,8 +1,8 @@
 # The versions in this file are maintained by renovate bot
-# Format: {source_image}:{tag}[@{optional_sha256_digest}],{target_image_without_tag}
+# Format: {source_image}:{tag}@{sha256_digest}],{target_image_without_tag}
 # Target image tag will be the same as source image tag
 
-node:16.15.0-alpine,cloudnativek8s/node
-nginx:1.22.0-alpine,cloudnativek8s/nginx
-openpolicyagent/opa:0.41.0,cloudnativek8s/opa
-openpolicyagent/opa:0.41.0-debug,cloudnativek8s/opa
+node:16.15.0-alpine@sha256:bb776153f81d6e931211e3cadd7eef92c811e7086993b685d1f40242d486b9bb,cloudnativek8s/node
+nginx:1.22.0-alpine@sha256:c90af9c78715f71ade64037ca54d3a0c0b6814362594b13643d03c5110085375,cloudnativek8s/nginx
+openpolicyagent/opa:0.41.0@sha256:c34704b307b3114f4c5d743c17b04fc663154245c7e8668eb9dcd49f2b00ca05,cloudnativek8s/opa
+openpolicyagent/opa:0.41.0-debug@sha256:594752f9e6993e3a3f91c615afc7522342d791b9ce5fed5596bf0f8e7ba0f2ce,cloudnativek8s/opa

--- a/workload.txt
+++ b/workload.txt
@@ -27,7 +27,7 @@ typeboot/executor:v1.0.2,cloudnativek8s/typeboot-executor:v1.0.2,done
 logstash:7.16.2,cloudnativek8s/logstash:7.16.2,done
 logstash:6.8.22,cloudnativek8s/logstash:6.8.22,done
 
-nginx:1.22.0-alpine,cloudnativek8s/nginx:1.22.0-alpine,ready
+nginx:1.22.1-alpine,cloudnativek8s/nginx:1.22.1-alpine,ready
 
 gcr.io/distroless/java-debian11:11,cloudnativek8s/distroless-java-debian11:11,done
 jekyll/builder:4.1.0,cloudnativek8s/jekyll-builder:4.1.0,done

--- a/workload.txt
+++ b/workload.txt
@@ -27,7 +27,7 @@ typeboot/executor:v1.0.2,cloudnativek8s/typeboot-executor:v1.0.2,done
 logstash:7.16.2,cloudnativek8s/logstash:7.16.2,done
 logstash:6.8.22,cloudnativek8s/logstash:6.8.22,done
 
-nginx:1.22.1-alpine,cloudnativek8s/nginx:1.22.1-alpine,ready
+nginx:1.22.0-alpine,cloudnativek8s/nginx:1.22.0-alpine,ready
 
 gcr.io/distroless/java-debian11:11,cloudnativek8s/distroless-java-debian11:11,done
 jekyll/builder:4.1.0,cloudnativek8s/jekyll-builder:4.1.0,done


### PR DESCRIPTION
Images to be managed by renovate are in renovated_images.txt.
`build.sh` builds only those which have changed (`git diff {last_tag} HEAD`). It also parses the old `workloads.txt` if it has changed to keep the backward compatibility.